### PR TITLE
Support for running Echidna in each contract 

### DIFF
--- a/plot.py
+++ b/plot.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import argparse
+import matplotlib.pyplot as plt
+import sys
+
+from ast             import literal_eval
+from csv             import reader
+from numpy           import mean, arange
+
+def parse_args():
+    # Create our argument parser
+    parser = argparse.ArgumentParser(
+        description="",
+        usage="plot.py [files]",
+    )
+
+    # Add arguments
+    parser.add_argument("files", help="XXX", nargs='+')
+
+    parser.add_argument(
+        "--outfile",
+        help="Write output to a file",
+        action="store",
+        type=str,
+        default="/dev/stdout"
+    )
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    data = []
+    for f in args.files:
+        try: 
+            data.append(literal_eval(open(f).read()))
+        except SyntaxError:
+            pass
+
+    coverage = []
+    for xs in data:
+        cs = list(map(lambda x: x[1], xs))
+        coverage.append(round(mean(cs),2))
+
+    print(coverage)
+    #with open(args.outfile, "w", newline='') as f:
+    plt.bar(arange(len(coverage)), coverage)
+    plt.xticks(arange(len(coverage)), args.files)
+    plt.show()
+
+if __name__ == "__main__":
+    main()

--- a/plot.py
+++ b/plot.py
@@ -28,6 +28,20 @@ def parse_args():
         default="out.png"
     )
 
+    parser.add_argument(
+        "--xlabel",
+        help="Label for axis X",
+        action="store",
+        type=str,
+    )
+
+    parser.add_argument(
+        "--ylabel",
+        help="Label for axis Y",
+        action="store",
+        type=str,
+    )
+
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -57,6 +71,11 @@ def main():
     plt.bar(arange(len(coverage)), coverage)
     plt.xticks(arange(len(coverage)), xlabels, rotation=70)
     plt.ylim([min(coverage)-10,max(coverage)+10])
+    if args.xlabel is not None:
+        plt.xlabel(args.xlabel)
+
+    if args.ylabel is not None:
+        plt.ylabel(args.ylabel)
     plt.savefig(args.outfile)
 
 if __name__ == "__main__":

--- a/plot.py
+++ b/plot.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import argparse
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import sys
 
 from ast             import literal_eval
 from csv             import reader
-from numpy           import mean, arange
+from numpy           import mean, arange, min, max
 
 def parse_args():
     # Create our argument parser
@@ -16,14 +18,14 @@ def parse_args():
     )
 
     # Add arguments
-    parser.add_argument("files", help="XXX", nargs='+')
+    parser.add_argument("files", help="Data files to plot", nargs='+')
 
     parser.add_argument(
         "--outfile",
         help="Write output to a file",
         action="store",
         type=str,
-        default="/dev/stdout"
+        default="out.png"
     )
 
     if len(sys.argv) == 1:
@@ -49,10 +51,13 @@ def main():
         coverage.append(round(mean(cs),2))
 
     print(coverage)
-    #with open(args.outfile, "w", newline='') as f:
+    plt.figure(figsize=(20,10))
+    #plt.rcParams.update({'font.size': 18})
+    xlabels = map(lambda x: x.split('/')[-1].replace(".out", ""), args.files)
     plt.bar(arange(len(coverage)), coverage)
-    plt.xticks(arange(len(coverage)), args.files)
-    plt.show()
+    plt.xticks(arange(len(coverage)), xlabels, rotation=70)
+    plt.ylim([min(coverage)-10,max(coverage)+10])
+    plt.savefig(args.outfile)
 
 if __name__ == "__main__":
     main()

--- a/run.py
+++ b/run.py
@@ -20,6 +20,13 @@ def parse_metadata(filename, prefix):
             r.append((prefix+'/'+contract_filename, contract_name))
     return r
 
+def parse_contracts(contracts):
+    r = []
+    cs = contracts.split(",")
+    for c in cs:
+        r.append(c.split(":"))
+    return r 
+
 def parse_args():
     # Create our argument parser
     parser = argparse.ArgumentParser(
@@ -61,6 +68,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--contracts",
+        help="Manually specify the contracts to use",
+        action="store",
+        type=str
+    )
+
+    parser.add_argument(
         "--outfile",
         help="Write output to a file",
         action="store",
@@ -83,8 +97,12 @@ def main():
         sys.exit(1)
 
     contracts = []
-    contracts = contracts + (parse_metadata('metadata/cve-info.csv', 'benchmarks/cve'))
-    contracts = contracts + (parse_metadata('metadata/zeus-info.csv', 'benchmarks/zeus'))
+    if (args.contracts is None):
+        contracts = contracts + (parse_metadata('metadata/cve-info.csv', 'benchmarks/cve'))
+        contracts = contracts + (parse_metadata('metadata/zeus-info.csv', 'benchmarks/zeus'))
+    else:
+        contracts = parse_contracts(args.contracts)
+    print(contracts)
 
     if args.nsample is not None:
         contracts = contracts[:args.nsample]

--- a/run.py
+++ b/run.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from csv import reader
+
+from numpy import mean
+
+from tools import tool_list, run_echidna
+
+def parse_metadata(filename, prefix):
+    r = []
+    with open(filename, newline='') as csvfile:
+        csvreader = reader(csvfile, delimiter=',')
+        for row in csvreader:
+            contract_filename = row[0]
+            contract_name = row[1]
+            if '.sol' not in contract_filename:
+                continue
+            r.append((prefix+'/'+contract_filename, contract_name))
+    return r
+
+def parse_args():
+    # Create our argument parser
+    parser = argparse.ArgumentParser(
+        description="",
+        usage="run.py tool [flag]",
+    )
+
+    # Add arguments
+    parser.add_argument("tool", help="Once of these tools to run: "+(str(tool_list)))
+
+    parser.add_argument(
+        "--nsample",
+        help="Run only on a sample of the total contracts",
+        action="store",
+        type=int
+    )
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    if args.tool not in tool_list:
+        print("ERROR: tool should be one of these:",",".join(map(repr,tool_list)))
+        sys.exit(1)
+
+    contracts = []
+    contracts = contracts + (parse_metadata('metadata/cve-info.csv', 'benchmarks/cve'))
+    contracts = contracts + (parse_metadata('metadata/zeus-info.csv', 'benchmarks/zeus'))
+ 
+    if args.nsample is not None:
+        contracts = contracts[:args.nsample]
+
+    data = []
+
+    for (f,c) in contracts:
+        if args.tool == "echidna":
+            coverage = run_echidna(f,c)
+            if coverage is not None:
+                data.append((f,coverage))
+
+    print("raw data:", data)
+    coverage = list(map(lambda x: x[1], data))
+    print("mean coverage:", mean(coverage))
+
+if __name__ == "__main__":
+    main()

--- a/run.py
+++ b/run.py
@@ -46,6 +46,21 @@ def parse_args():
         default=5
     )
 
+    parser.add_argument(
+        "--extra-args",
+        help="Additional arguments for the tool",
+        action="store",
+        type=str,
+    )
+
+    parser.add_argument(
+        "--outfile",
+        help="Write output to a file",
+        action="store",
+        type=str,
+        default="/dev/stdout"
+    )
+
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
@@ -63,11 +78,11 @@ def main():
     contracts = []
     contracts = contracts + (parse_metadata('metadata/cve-info.csv', 'benchmarks/cve'))
     contracts = contracts + (parse_metadata('metadata/zeus-info.csv', 'benchmarks/zeus'))
- 
+
     if args.nsample is not None:
         contracts = contracts[:args.nsample]
 
-    print(contracts)
+    contracts = list(map(lambda p: (p[0], p[1], args.extra_args), contracts))
     data = []
 
     if args.tool == "echidna":
@@ -77,9 +92,12 @@ def main():
         data = p.map(func, contracts)
 
     data = list(filter(lambda x: x[1] is not None, data))
-    print("raw data:", data)
-    coverage = list(map(lambda x: x[1], data))
-    print("mean coverage:", round(mean(coverage),2))
+    with open(args.outfile, "w", newline='') as f:
+        f.write("raw data: "+ str(data))
+        f.write('\n')
+        coverage = list(map(lambda x: x[1], data))
+        f.write("mean coverage:"+ str(round(mean(coverage),2)))
+        f.write('\n')
 
 if __name__ == "__main__":
     main()

--- a/run.py
+++ b/run.py
@@ -46,6 +46,14 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--reps",
+        help="Number of experiment repetitions",
+        action="store",
+        type=int,
+        default=1
+    )
+
+    parser.add_argument(
         "--extra-args",
         help="Additional arguments for the tool",
         action="store",
@@ -81,14 +89,18 @@ def main():
     if args.nsample is not None:
         contracts = contracts[:args.nsample]
 
-    contracts = list(map(lambda p: (p[0], p[1], args.extra_args), contracts))
+    inputs = []
+    for r in range(args.reps):
+        inputs = inputs + list(map(lambda p: (p[0], p[1], r, args.extra_args), contracts))
+
+    print(inputs)
     data = []
 
     if args.tool == "echidna":
         func = run_echidna
 
     with Pool(args.procs) as p:
-        data = p.map(func, contracts)
+        data = p.map(func, inputs)
 
     data = list(filter(lambda x: x[1] is not None, data))
     with open(args.outfile, "w", newline='') as f:

--- a/run.py
+++ b/run.py
@@ -5,7 +5,6 @@ import sys
 
 from csv             import reader
 from multiprocessing import Pool
-from numpy           import mean
 
 from tools import tool_list, run_echidna
 
@@ -93,11 +92,7 @@ def main():
 
     data = list(filter(lambda x: x[1] is not None, data))
     with open(args.outfile, "w", newline='') as f:
-        f.write("raw data: "+ str(data))
-        f.write('\n')
-        coverage = list(map(lambda x: x[1], data))
-        f.write("mean coverage:"+ str(round(mean(coverage),2)))
-        f.write('\n')
+        f.write(str(data))
 
 if __name__ == "__main__":
     main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,3 @@
+from .echidna import run_echidna
+
+tool_list = ["echidna"]

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -3,10 +3,10 @@ import shutil
 import time
 
 def run_echidna(p):
-    (filename, contract, extra_args) = p
+    (filename, contract, rep, extra_args) = p
     coverage = None
     
-    cdir = "temp/"+filename.replace("/","_")+".dir"
+    cdir = "temp/echidna_"+filename.replace("/","_")+"_"+str(rep)+".dir"
     shutil.rmtree(cdir, ignore_errors=True)
     os.mkdir(cdir)
     os.chdir(cdir)
@@ -29,4 +29,4 @@ def run_echidna(p):
                 coverage = int(l.split(" ")[2])
     
     os.chdir('../..')
-    return (filename, coverage, end - start)
+    return (filename, coverage, rep, end - start)

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import time
 
 def run_echidna(p):
     (filename, contract, extra_args) = p
@@ -18,8 +19,9 @@ def run_echidna(p):
             f.write(extra_args)
 
     cmd = 'echidna-test ../../'+filename+' '+contract+' --config echidna.yaml > echidna.out 2> echidna.err'
-    #print(cmd)
+    start = time.time()
     os.system(cmd)
+    end = time.time()
     with open("echidna.out", newline='') as f:
         for l in f.readlines():
             l = l.replace('\n','')
@@ -27,4 +29,4 @@ def run_echidna(p):
                 coverage = int(l.split(" ")[2])
     
     os.chdir('../..')
-    return (filename, coverage)
+    return (filename, coverage, end - start)

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -10,6 +10,7 @@ def run_echidna(p):
     shutil.rmtree(cdir, ignore_errors=True)
     os.mkdir(cdir)
     os.chdir(cdir)
+    os.mkdir("corpus")
 
     config = open("../../tools/echidna.yaml","r").read()
 
@@ -18,7 +19,7 @@ def run_echidna(p):
         if (extra_args is not None):
             f.write(extra_args)
 
-    cmd = 'echidna-test ../../'+filename+' '+contract+' --config echidna.yaml > echidna.out 2> echidna.err'
+    cmd = 'echidna-test ../../'+filename+' --contract '+contract+' --config echidna.yaml > echidna.out 2> echidna.err'
     start = time.time()
     os.system(cmd)
     end = time.time()

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -5,19 +5,19 @@ def run_echidna(p):
     (filename, contract, extra_args) = p
     coverage = None
     
-    cdir = filename.replace("/","_")+".dir"
+    cdir = "temp/"+filename.replace("/","_")+".dir"
     shutil.rmtree(cdir, ignore_errors=True)
     os.mkdir(cdir)
     os.chdir(cdir)
 
-    config = open("../tools/echidna.yaml","r").read()
+    config = open("../../tools/echidna.yaml","r").read()
 
     with open("echidna.yaml", "w+", newline='') as f:
         f.write(config)
         if (extra_args is not None):
             f.write(extra_args)
 
-    cmd = 'echidna-test ../'+filename+' '+contract+' --config echidna.yaml > echidna.out 2> echidna.err'
+    cmd = 'echidna-test ../../'+filename+' '+contract+' --config echidna.yaml > echidna.out 2> echidna.err'
     #print(cmd)
     os.system(cmd)
     with open("echidna.out", newline='') as f:
@@ -26,5 +26,5 @@ def run_echidna(p):
             if "Unique instructions: " in l:
                 coverage = int(l.split(" ")[2])
     
-    os.chdir('..')
+    os.chdir('../..')
     return (filename, coverage)

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -1,13 +1,23 @@
 import os
+import shutil
 
-def run_echidna(filename, contract):
-    coverage = None 
-    cmd = 'echidna-test '+filename+' '+contract+' --config tools/echidna.yaml > echidna.out 2> echidna.err'
+def run_echidna(p):
+    (filename, contract) = p
+    coverage = None
+    
+    cdir = filename.replace("/","_")+".dir"
+    shutil.rmtree(cdir)
+    os.mkdir(cdir)
+    os.chdir(cdir)
+
+    cmd = 'echidna-test ../'+filename+' '+contract+' --config ../tools/echidna.yaml > echidna.out 2> echidna.err'
+    print(cmd)
     os.system(cmd)
     with open("echidna.out", newline='') as f:
         for l in f.readlines():
             l = l.replace('\n','')
             if "Unique instructions: " in l:
                 coverage = int(l.split(" ")[2])
-
-    return coverage
+    
+    os.chdir('..')
+    return (filename, coverage)

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -2,16 +2,23 @@ import os
 import shutil
 
 def run_echidna(p):
-    (filename, contract) = p
+    (filename, contract, extra_args) = p
     coverage = None
     
     cdir = filename.replace("/","_")+".dir"
-    shutil.rmtree(cdir)
+    shutil.rmtree(cdir, ignore_errors=True)
     os.mkdir(cdir)
     os.chdir(cdir)
 
-    cmd = 'echidna-test ../'+filename+' '+contract+' --config ../tools/echidna.yaml > echidna.out 2> echidna.err'
-    print(cmd)
+    config = open("../tools/echidna.yaml","r").read()
+
+    with open("echidna.yaml", "w+", newline='') as f:
+        f.write(config)
+        if (extra_args is not None):
+            f.write(extra_args)
+
+    cmd = 'echidna-test ../'+filename+' '+contract+' --config echidna.yaml > echidna.out 2> echidna.err'
+    #print(cmd)
     os.system(cmd)
     with open("echidna.out", newline='') as f:
         for l in f.readlines():

--- a/tools/echidna.py
+++ b/tools/echidna.py
@@ -1,0 +1,13 @@
+import os
+
+def run_echidna(filename, contract):
+    coverage = None 
+    cmd = 'echidna-test '+filename+' '+contract+' --config tools/echidna.yaml > echidna.out 2> echidna.err'
+    os.system(cmd)
+    with open("echidna.out", newline='') as f:
+        for l in f.readlines():
+            l = l.replace('\n','')
+            if "Unique instructions: " in l:
+                coverage = int(l.split(" ")[2])
+
+    return coverage

--- a/tools/echidna.yaml
+++ b/tools/echidna.yaml
@@ -1,8 +1,8 @@
 shrinkLimit: 1
-testLimit: 10000
-seqLen: 5
+testLimit: 500000
+seqLen: 100
 dashboard: false
 checkAsserts: true
 format: text
 coverage: true
-cryticArgs: ["--solc-solcs-bin","solc-0.4.24"]
+cryticArgs: ["--solc-solcs-bin","solc"]

--- a/tools/echidna.yaml
+++ b/tools/echidna.yaml
@@ -5,3 +5,4 @@ dashboard: false
 checkAsserts: true
 format: text
 coverage: true
+cryticArgs: ["--solc-solcs-bin","solc-0.4.24"]

--- a/tools/echidna.yaml
+++ b/tools/echidna.yaml
@@ -1,0 +1,7 @@
+shrinkLimit: 1
+testLimit: 10000
+seqLen: 5
+dashboard: false
+checkAsserts: true
+format: text
+coverage: true

--- a/tools/echidna.yaml
+++ b/tools/echidna.yaml
@@ -5,4 +5,5 @@ dashboard: false
 checkAsserts: true
 format: text
 coverage: true
-cryticArgs: ["--solc-solcs-bin","solc"]
+corpusDir: "corpus"
+cryticArgs: ["--solc","solc-0.4.21"]


### PR DESCRIPTION
This PR adds support to test tools in every contract, and in particular implements some code to run Echidna and collect a coverage metric. To execute: 

```
$ ./run.py echidna --procs 5 --nsample 10 --outfile echidna.out
```

This will run a echidna on a sample of 5 contracts using 5 concurrent processes. The results will be saved in `echidna.out`.

More tools for smart contract fuzzing/symbolic execution can be easily added.